### PR TITLE
Upgrade Jackson from 2.x to 3.1.0 for Quarkus 4 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jackson.version>2.17.2</jackson.version>
+        <jackson.version>3.1.0</jackson.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
         <junit.jupiter.version>5.10.3</junit.jupiter.version>
@@ -63,7 +63,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
+                <groupId>tools.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
                 <type>pom</type>
@@ -74,7 +74,7 @@
     
     <dependencies>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/io/mvnpm/importmap/Aggregator.java
+++ b/src/main/java/io/mvnpm/importmap/Aggregator.java
@@ -1,7 +1,7 @@
 package io.mvnpm.importmap;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -111,7 +111,7 @@ public class Aggregator {
         try {
             Imports i = aggregate(root, scanClassPath);
             return this.objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(i);
-        } catch (JsonProcessingException ex) {
+        } catch (JacksonException ex) {
             throw new RuntimeException(ex);
         }
     }
@@ -119,7 +119,7 @@ public class Aggregator {
     public String aggregateAsJson(Imports imports) {
         try {
             return this.objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(imports);
-        } catch (JsonProcessingException ex) {
+        } catch (JacksonException ex) {
             throw new RuntimeException(ex);
         }
     }

--- a/src/main/java/io/mvnpm/importmap/ImportsDataBinding.java
+++ b/src/main/java/io/mvnpm/importmap/ImportsDataBinding.java
@@ -1,7 +1,7 @@
 package io.mvnpm.importmap;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import io.mvnpm.importmap.model.Imports;
 
 /**
@@ -17,7 +17,7 @@ public class ImportsDataBinding {
     public static Imports toImports(String json) {
         try {
             return objectMapper.readValue(json, Imports.class);
-        } catch (JsonProcessingException ex) {
+        } catch (JacksonException ex) {
             throw new RuntimeException("Error while binding to Imports Object. Json = [" + json + "]", ex);
         }
     }
@@ -25,7 +25,7 @@ public class ImportsDataBinding {
     public static String toJson(Imports imports){
         try {
             return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(imports);
-        } catch (JsonProcessingException ex) {
+        } catch (JacksonException ex) {
             throw new RuntimeException("Error while binding to Json. Imports Object = [" + imports + "]", ex);
         }
     }

--- a/src/test/java/io/mvnpm/importmap/AggregatorTest.java
+++ b/src/test/java/io/mvnpm/importmap/AggregatorTest.java
@@ -1,8 +1,8 @@
 package io.mvnpm.importmap;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AfterAll;
@@ -33,7 +33,7 @@ public class AggregatorTest {
     }
 
     @Test
-    public void testAggregateAsJson() throws JsonProcessingException{
+    public void testAggregateAsJson() throws JacksonException{
         Aggregator aggregator = new Aggregator();
         String importmap = aggregator.aggregateAsJson();
         
@@ -42,60 +42,60 @@ public class AggregatorTest {
         ObjectMapper mapper = new ObjectMapper();
         Map<String, Map<String, String>> actualMap = mapper.readValue(importmap, new TypeReference<>() {});
 
-        assertEquals("/_static/labs/ssr-dom-shim/1.2.0/", actualMap.get("imports").get("@lit-labs/ssr-dom-shim/"));
+        assertEquals("/_static/at/lit-labs/labs/ssr-dom-shim/1.6.0/", actualMap.get("imports").get("@lit-labs/ssr-dom-shim/"));
         assertEquals("/_static/trusted-types/2.0.7/index.js", actualMap.get("imports").get("@types/trusted-types"));
         assertEquals("/_static/lit-element/4.0.6/index.js", actualMap.get("imports").get("lit-element"));
-        assertEquals("/_static/reactive-element/2.0.4/reactive-element.js", actualMap.get("imports").get("@lit/reactive-element"));
+        assertEquals("/_static/reactive-element/2.1.2/reactive-element.js", actualMap.get("imports").get("@lit/reactive-element"));
         assertEquals("/_static/lit/3.1.4/index.js", actualMap.get("imports").get("lit"));
         assertEquals("/_static/lit-element/4.0.6/", actualMap.get("imports").get("lit-element/"));
         assertEquals("/_static/lit-html/3.1.4/", actualMap.get("imports").get("lit-html/"));
         assertEquals("/_static/trusted-types/2.0.7/", actualMap.get("imports").get("@types/trusted-types/"));
         assertEquals("/_static/lit/3.1.4/", actualMap.get("imports").get("lit/"));
-        assertEquals("/_static/reactive-element/2.0.4/", actualMap.get("imports").get("@lit/reactive-element/"));
+        assertEquals("/_static/reactive-element/2.1.2/", actualMap.get("imports").get("@lit/reactive-element/"));
         assertEquals("/_static/lit-html/3.1.4/lit-html.js", actualMap.get("imports").get("lit-html"));
-        assertEquals("/_static/labs/ssr-dom-shim/1.2.0/index.js", actualMap.get("imports").get("@lit-labs/ssr-dom-shim"));
+        assertEquals("/_static/at/lit-labs/labs/ssr-dom-shim/1.6.0/index.js", actualMap.get("imports").get("@lit-labs/ssr-dom-shim"));
     }
     
     
     @Test
-    public void testAggregateAsJs() throws JsonProcessingException{
+    public void testAggregateAsJs() throws JacksonException{
         Aggregator aggregator = new Aggregator();
         String importjs = aggregator.aggregateAsJs();
         
         System.out.println(importjs);
         
-        assertTrue(importjs.contains("/_static/labs/ssr-dom-shim/1.2.0/"));
+        assertTrue(importjs.contains("/_static/at/lit-labs/labs/ssr-dom-shim/1.6.0/"));
         assertTrue(importjs.contains("/_static/trusted-types/2.0.7/index.js"));
         assertTrue(importjs.contains("/_static/lit-element/4.0.6/index.js"));
-        assertTrue(importjs.contains("/_static/reactive-element/2.0.4/reactive-element.js"));
+        assertTrue(importjs.contains("/_static/reactive-element/2.1.2/reactive-element.js"));
         assertTrue(importjs.contains("/_static/lit/3.1.4/index.js"));
         assertTrue(importjs.contains("/_static/lit-element/4.0.6/"));
         assertTrue(importjs.contains("/_static/lit-html/3.1.4/"));
         assertTrue(importjs.contains("/_static/trusted-types/2.0.7/"));
         assertTrue(importjs.contains("/_static/lit/3.1.4/"));
-        assertTrue(importjs.contains("/_static/reactive-element/2.0.4/"));
+        assertTrue(importjs.contains("/_static/reactive-element/2.1.2/"));
         assertTrue(importjs.contains("/_static/lit-html/3.1.4/lit-html.js"));
-        assertTrue(importjs.contains("/_static/labs/ssr-dom-shim/1.2.0/index.js"));
+        assertTrue(importjs.contains("/_static/at/lit-labs/labs/ssr-dom-shim/1.6.0/index.js"));
     }
     
     @Test
-    public void testAggregateAsJsWithRoot() throws JsonProcessingException{
+    public void testAggregateAsJsWithRoot() throws JacksonException{
         Aggregator aggregator = new Aggregator();
         String importjs = aggregator.aggregateAsJs("/node_modules");
         
         System.out.println(importjs);
         
-        assertTrue(importjs.contains("/node_modules/_static/labs/ssr-dom-shim/1.2.0/"));
+        assertTrue(importjs.contains("/node_modules/_static/at/lit-labs/labs/ssr-dom-shim/1.6.0/"));
         assertTrue(importjs.contains("/node_modules/_static/trusted-types/2.0.7/index.js"));
         assertTrue(importjs.contains("/node_modules/_static/lit-element/4.0.6/index.js"));
-        assertTrue(importjs.contains("/node_modules/_static/reactive-element/2.0.4/reactive-element.js"));
+        assertTrue(importjs.contains("/node_modules/_static/reactive-element/2.1.2/reactive-element.js"));
         assertTrue(importjs.contains("/node_modules/_static/lit/3.1.4/index.js"));
         assertTrue(importjs.contains("/node_modules/_static/lit-element/4.0.6/"));
         assertTrue(importjs.contains("/node_modules/_static/lit-html/3.1.4/"));
         assertTrue(importjs.contains("/node_modules/_static/trusted-types/2.0.7/"));
         assertTrue(importjs.contains("/node_modules/_static/lit/3.1.4/"));
-        assertTrue(importjs.contains("/node_modules/_static/reactive-element/2.0.4/"));
+        assertTrue(importjs.contains("/node_modules/_static/reactive-element/2.1.2/"));
         assertTrue(importjs.contains("/node_modules/_static/lit-html/3.1.4/lit-html.js"));
-        assertTrue(importjs.contains("/node_modules/_static/labs/ssr-dom-shim/1.2.0/index.js"));
+        assertTrue(importjs.contains("/node_modules/_static/at/lit-labs/labs/ssr-dom-shim/1.6.0/index.js"));
     }
 }


### PR DESCRIPTION
Quarkus 4 is moving to Jackson 3, and since Quarkus Dev UI depends on this library, it needs to follow suit.

Jackson 3 changed the Maven groupId (`com.fasterxml.jackson` → `tools.jackson`), the Java package name accordingly, and replaced `JsonProcessingException` with `JacksonException`. The API surface used by this library (`ObjectMapper.readValue`, `writeValueAsString`, `writerWithDefaultPrettyPrinter`) is unchanged, so the migration is purely mechanical.

Test assertions were also updated to match current transitive dependency versions (`ssr-dom-shim` 1.2.0 → 1.6.0, `reactive-element` 2.0.4 → 2.1.2).